### PR TITLE
Add Makefile to build using docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+DOCKERFILE_VERSION := $(shell git log --format=%H Dockerfile | head -1)
+DOCKER_IMAGE := grpc-haskell:$(DOCKERFILE_VERSION)
+
+all: build
+
+build-docker:
+	git diff --exit-code Dockerfile
+	docker build -t $(DOCKER_IMAGE) .
+
+build: build-docker
+	stack build --docker-repo=$(DOCKER_IMAGE)

--- a/stack.yaml
+++ b/stack.yaml
@@ -64,3 +64,6 @@ nix:
   pure: false
   shell-file: release.nix
   nix-shell-options: ["-A", "grpc-haskell.env"]
+
+docker:
+  enable: true


### PR DESCRIPTION
This PR builds upon Fabs/gRPC-haskell by adding a very simple `Makefile` and configuring `stack.yaml` to build in the new docker image.